### PR TITLE
Home Menu Options UI Adjustments

### DIFF
--- a/lib/pages/home/HomePage.dart
+++ b/lib/pages/home/HomePage.dart
@@ -116,7 +116,8 @@ class _HomePageState extends State<HomePage> {
                                     child: Stack(
                                       children: <Widget>[
                                         Positioned(
-                                          top: 0,
+                                          top: -20,
+                                          left: 10,
                                           child: PlatformSvg.asset(
                                             listHomeActions[index].imgUrl,
                                             width:
@@ -140,7 +141,7 @@ class _HomePageState extends State<HomePage> {
                                     ),
                                   )))),
                       staggeredTileBuilder: (int index) =>
-                          new StaggeredTile.count(2, index.isOdd ? 1.5 : 2.2),
+                          new StaggeredTile.count(2, index.isOdd ? 1.5 : 1.96),
                       mainAxisSpacing: 15.0,
                       crossAxisSpacing: 5.0,
                     ),


### PR DESCRIPTION
Slightly decreased the height of the option boxes in order to fit the boxes in one screen . Previously, it was being slightly cut off by the top header or the bottom nav bar due to the boxes being a little too long, even when I made my Chrome window for the preview as long vertically as possible.

Changed positioning of the option images slightly so the option titles do not clash with the dark colours of the background images.